### PR TITLE
Fix text layout problems on different size screens

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -41,13 +41,6 @@ h1, p, span {
     text-align: center;
 }
 
-h1 {
-    margin-top: 25px;
-    margin-bottom: 25px;
-    font-size: 32px;
-    font-weight: 300;
-}
-
 p {
     margin-bottom: 25px;
     font-size: 22px;
@@ -88,7 +81,7 @@ p {
     display: flex;
     flex-basis: 100%;
     margin-top: 50px;
-    margin-bottom: 100px;
+    margin-bottom: 75px;
     margin-right: 30%;
     margin-left: 30%;
     justify-content: center;
@@ -100,7 +93,7 @@ p {
 }
 
 #console-name {
-    margin-bottom: 5%;
+    margin-bottom: 75px;
     font-size: 25px;
 }
 

--- a/index.html
+++ b/index.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Welcome</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta charset="UTF-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        <meta http-equiv="X-UA-Compatible" content="ie=edge">
+        <title>Welcome - Robert Jardine</title>
 
         <link rel="stylesheet" href="./css/main.css"/>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
@@ -12,7 +13,6 @@
         <script src="./js/main.js"></script>
     </head>
     <body>
-
         <div id="icons">
             <a href="https://www.linkedin.com/in/robert-jardine-30784390" target="_blank">
                 <span id="li-button" class="fa fa-linkedin fa-2x"></span>
@@ -32,9 +32,9 @@
                 <span id="header"></span>
                 <span id="block-char">&#9611</span>
             </div>
-            <span id="boku-ha">。。。</span>
+            <p id="boku-ha">。。。</p>
             <p><span id="prefix">I am a </span><span id="i-am">. . .</span></p>
-            <span>休憩無し、上達して行く</span>
+            <p>休憩無し、上達して行く</p>
             <p>My goal is to continuously learn and grow</p>
             <p>プロジェクトなどを是非ご覧下さい</p>
             <p>Checkout some of my work</p>
@@ -71,6 +71,5 @@
                 </div>
             </div>
         </div>
-        
     </body>
 </html>


### PR DESCRIPTION
Replace '%' with 'px' for text elements using margin-top and margin-bottom to get a uniform look across screen sizes.